### PR TITLE
fixed sidedraw navbar appearing on large screens

### DIFF
--- a/developer-home.html
+++ b/developer-home.html
@@ -45,7 +45,7 @@
             </button>
             <!-- Offcanvas -->
             <div
-              class="offcanvas offcanvas-end"
+              class="offcanvas offcanvas-end d-lg-none"
               tabindex="-1"
               id="offcanvasNavbar"
               aria-labelledby="offcanvasNavbarLabel"

--- a/login.html
+++ b/login.html
@@ -22,7 +22,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <!-- Offcanvas -->
-            <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
+            <div class="offcanvas offcanvas-end d-lg-none" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
                 <div class="offcanvas-header">
                     <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Menu</h5>
                     <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>


### PR DESCRIPTION
This PR addresses the issue where the side-draw navbar was incorrectly appearing on desktop screens. It ensures that the side-draw navbar is only visible on smaller screens as intended.

Changes: Added the "d-lg-none" bootstrap utility class to the side-draw navbar (offcanvas).